### PR TITLE
[Thrift] Fix a bug when ThriftClientImpl close() error

### DIFF
--- a/be/src/runtime/client_cache.cpp
+++ b/be/src/runtime/client_cache.cpp
@@ -82,10 +82,7 @@ Status ClientCacheHelper::reopen_client(client_factory factory_method, void** cl
     const std::string ipaddress = info->ipaddress();
     int port = info->port();
 
-    // We don't expect Close() to fail. Even if it fails, we should continue on to delete
-    // the transport and remove it from the map.
-    Status status = info->close();
-    DCHECK(status.ok());
+    info->close();
 
     // TODO: Thrift TBufferedTransport cannot be re-opened after Close() because it does
     // not clean up internal buffers it reopens. To work around this issue, create a new

--- a/be/src/util/thrift_client.cpp
+++ b/be/src/util/thrift_client.cpp
@@ -78,14 +78,14 @@ Status ThriftClientImpl::open_with_retry(int num_tries, int wait_ms) {
 
 void ThriftClientImpl::close() {
     try {
-        if (_transport.get() != NULL && _transport->isOpen()) _transport->close();
+        if (_transport.get() != nullptr && _transport->isOpen()) _transport->close();
     } catch (const apache::thrift::transport::TTransportException& e) {
         LOG(INFO) << "Error closing connection to: " << ipaddress() << ":" << port()
                   << ", ignoring (" << e.what() << ")";
         // Forcibly close the socket (since the transport may have failed to get that far
         // during close())
         try {
-            if (_socket.get() != NULL) _socket->close();
+            if (_socket.get() != nullptr) _socket->close();
         } catch (const apache::thrift::transport::TTransportException& e) {
             LOG(INFO) << "Error closing socket to: " << ipaddress() << ":" << port()
                       << ", ignoring (" << e.what() << ")";

--- a/be/src/util/thrift_client.cpp
+++ b/be/src/util/thrift_client.cpp
@@ -15,11 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <util/thrift_client.h>
+#include "util/thrift_client.h"
 
 #include <ostream>
+#include <string>
 
 #include <boost/assign.hpp>
+
+#include "gutil/strings/substitute.h"
 
 namespace doris {
 
@@ -28,13 +31,21 @@ Status ThriftClientImpl::open() {
         if (!_transport->isOpen()) {
             _transport->open();
         }
-    } catch (apache::thrift::transport::TTransportException& e) {
-        std::stringstream msg;
-        msg << "Couldn't open transport for " << ipaddress() << ":" << port()
-            << "(" << e.what() << ")";
-        return Status::ThriftRpcError(msg.str());
+    } catch (const apache::thrift::transport::TTransportException& e) {
+        try {
+            _transport->close();
+        } catch (const apache::thrift::transport::TTransportException& e) {
+            VLOG(1) << "Error closing socket to: " << ipaddress() << ":" << port()
+                    << ", ignoring (" << e.what() << ")";
+        }
+        // In certain cases in which the remote host is overloaded, this failure can
+        // happen quite frequently. Let's print this error message without the stack
+        // trace as there aren't many callers of this function.
+        const std::string& err_msg = strings::Substitute("Couldn't open transport for $0:$1 ($2)",
+                                                         ipaddress(), port(), e.what());
+        VLOG(1) << err_msg;
+        return Status::ThriftRpcError(err_msg);
     }
-
     return Status::OK();
 }
 
@@ -65,12 +76,21 @@ Status ThriftClientImpl::open_with_retry(int num_tries, int wait_ms) {
     return status;
 }
 
-Status ThriftClientImpl::close() {
-    if (_transport->isOpen()) {
-        _transport->close();
+void ThriftClientImpl::close() {
+    try {
+        if (_transport.get() != NULL && _transport->isOpen()) _transport->close();
+    } catch (const apache::thrift::transport::TTransportException& e) {
+        LOG(INFO) << "Error closing connection to: " << ipaddress() << ":" << port()
+                  << ", ignoring (" << e.what() << ")";
+        // Forcibly close the socket (since the transport may have failed to get that far
+        // during close())
+        try {
+            if (_socket.get() != NULL) _socket->close();
+        } catch (const apache::thrift::transport::TTransportException& e) {
+            LOG(INFO) << "Error closing socket to: " << ipaddress() << ":" << port()
+                      << ", ignoring (" << e.what() << ")";
+        }
     }
-
-    return Status::OK();
 }
 
 }

--- a/be/src/util/thrift_client.h
+++ b/be/src/util/thrift_client.h
@@ -62,7 +62,7 @@ public:
 
     // close the connection with the remote server. May be called
     // repeatedly.
-    Status close();
+    void close();
 
     // Set the connect timeout
     void set_conn_timeout(int ms) {


### PR DESCRIPTION
In ThriftClientImpl close(), the under layer TTransport may throw an exception,
this pathch catch the exception to avoid crash.